### PR TITLE
🐛(style) fix breakpoint types and styling

### DIFF
--- a/cunningham.ts
+++ b/cunningham.ts
@@ -145,8 +145,8 @@ const config = {
         breakpoints: {
           xxs: "320px",
           xs: "480px",
-          mobile: 768,
-          tablet: 1024,
+          mobile: "768px",
+          tablet: "1024px",
         },
       },
       components: {

--- a/src/components/button/index.scss
+++ b/src/components/button/index.scss
@@ -15,11 +15,12 @@
   background-position: 50% 50%;
   background-repeat: no-repeat;
   width: 214px;
-  height: 56px;
+  height: 56px !important;
   border: "none";
   cursor: pointer;
   &:disabled {
-    background-image: url("/proconnect-content-disabled.svg");
+    background-color: var(--c--theme--colors--greyscale-100) !important;
+    background-image: url("/proconnect-content-disabled.svg") !important;
   }
 }
 .c__button {

--- a/src/components/layout/left-panel/index.scss
+++ b/src/components/layout/left-panel/index.scss
@@ -13,6 +13,7 @@
   z-index: 999;
   width: 100dvw;
   height: calc(100dvh - 52px);
+  overflow-y: auto;
   border-right: 1px solid var(--c--theme--colors--greyscale-200);
   position: fixed;
   background-color: var(--c--theme--colors--greyscale-000);

--- a/src/hooks/useResponsive.tsx
+++ b/src/hooks/useResponsive.tsx
@@ -3,6 +3,12 @@ import config from "../../cunningham";
 
 export const useResponsive = () => {
   const [width, setWidth] = useState(window.innerWidth);
+  const mobile = parseInt(
+    config.themes.default.theme.breakpoints.mobile.replace("px", "")
+  );
+  const tablet = parseInt(
+    config.themes.default.theme.breakpoints.tablet.replace("px", "")
+  );
 
   const handleWindowSizeChange = () => {
     setWidth(window.innerWidth);
@@ -16,9 +22,9 @@ export const useResponsive = () => {
     };
   }, []);
 
-  const isMobile = width <= config.themes.default.theme.breakpoints.mobile;
-  const isTablet = width <= config.themes.default.theme.breakpoints.tablet;
-  const isDesktop = width > config.themes.default.theme.breakpoints.tablet;
+  const isMobile = width <= mobile;
+  const isTablet = width <= tablet;
+  const isDesktop = width > tablet;
 
   return { isMobile, isTablet, isDesktop };
 };

--- a/src/index.scss
+++ b/src/index.scss
@@ -1,2 +1,3 @@
 @use "./library";
 @use "cunningham-tokens";
+@import url("./assets/fonts/Marianne/Marianne-font.css");

--- a/src/library.scss
+++ b/src/library.scss
@@ -1,7 +1,6 @@
 @use "@openfun/cunningham-react/fonts";
 @use "@openfun/cunningham-react/icons";
 @use "@openfun/cunningham-react/style";
-@use "cunningham-tokens";
 @use "cunningham-custom-style";
 @use "./components/button";
 @use "./components/tree-view";
@@ -23,4 +22,3 @@
 @use "./components/form/select";
 @use "./components/form/textarea";
 @use "./components/datagrid";
-@import url("./assets/fonts/Marianne/Marianne-font.css");


### PR DESCRIPTION
- Updated breakpoint values in cunningham.ts to use string type with 'px'
- Added overflow-y to left panel
- Updated useResponsive hook to parse breakpoint values correctly