### PR TITLE
🔧(fonts) update Marianne font paths and import

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -1,4 +1,3 @@
-
 import { CunninghamProvider } from "../src/components/Provider/Provider";
 import "./../src/index.scss";
 import "./../src/style-stories.scss";
@@ -8,7 +7,7 @@ import React from "react";
 const preview: Preview = {
   decorators: [
     (Story) => (
-      <CunninghamProvider theme="dsfr">
+      <CunninghamProvider>
         <div>
           <Story />
         </div>

--- a/src/assets/fonts/Marianne/Marianne-font.css
+++ b/src/assets/fonts/Marianne/Marianne-font.css
@@ -1,16 +1,17 @@
 @font-face {
   font-family: Marianne;
   src:
-    url('Marianne-Thin.woff2') format('woff2'),
-    url('Marianne-Thin.woff') format('woff');
+    url(':/assets/fonts/Marianne/Marianne-Thin.woff2') format('woff2'),
+    url(':/assets/fonts/Marianne/Marianne-Thin.woff') format('woff');
   font-weight: 100;
 }
+
 
 @font-face {
   font-family: Marianne;
   src:
-    url('Marianne-Thin_Italic.woff2') format('woff2'),
-    url('Marianne-Thin_Italic.woff') format('woff');
+    url(':/assets/fonts/Marianne/Marianne-Thin_Italic.woff2') format('woff2'),
+    url(':/assets/fonts/Marianne/Marianne-Thin_Italic.woff') format('woff');
   font-weight: 100;
   font-style: italic;
 }
@@ -18,16 +19,16 @@
 @font-face {
   font-family: Marianne;
   src:
-    url('Marianne-Light.woff2') format('woff2'),
-    url('Marianne-Light.woff') format('woff');
+    url(':/assets/fonts/Marianne/Marianne-Light.woff2') format('woff2'),
+    url(':/assets/fonts/Marianne/Marianne-Light.woff') format('woff');
   font-weight: 300;
 }
 
 @font-face {
   font-family: Marianne;
   src:
-    url('Marianne-Light_Italic.woff2') format('woff2'),
-    url('Marianne-Light_Italic.woff') format('woff');
+    url(':/assets/fonts/Marianne/Marianne-Light_Italic.woff2') format('woff2'),
+    url(':/assets/fonts/Marianne/Marianne-Light_Italic.woff') format('woff');
   font-weight: 300;
   font-style: italic;
 }
@@ -35,16 +36,16 @@
 @font-face {
   font-family: Marianne;
   src:
-    url('Marianne-Regular.woff2') format('woff2'),
-    url('Marianne-Regular.woff') format('woff');
+    url(':/assets/fonts/Marianne/Marianne-Regular.woff2') format('woff2'),
+    url(':/assets/fonts/Marianne/Marianne-Regular.woff') format('woff');
   font-weight: 400;
 }
 
 @font-face {
   font-family: Marianne;
   src:
-    url('Marianne-Regular_Italic.woff2') format('woff2'),
-    url('Marianne-Regular_Italic.woff') format('woff');
+    url(':/assets/fonts/Marianne/Marianne-Regular_Italic.woff2') format('woff2'),
+    url(':/assets/fonts/Marianne/Marianne-Regular_Italic.woff') format('woff');
   font-weight: 400;
   font-style: italic;
 }
@@ -52,16 +53,16 @@
 @font-face {
   font-family: Marianne;
   src:
-    url('Marianne-Medium.woff2') format('woff2'),
-    url('Marianne-Medium.woff') format('woff');
+    url(':/assets/fonts/Marianne/Marianne-Medium.woff2') format('woff2'),
+    url(':/assets/fonts/Marianne/Marianne-Medium.woff') format('woff');
   font-weight: 500;
 }
 
 @font-face {
   font-family: Marianne;
   src:
-    url('Marianne-Medium_Italic.woff2') format('woff2'),
-    url('Marianne-Medium_Italic.woff') format('woff');
+    url(':/assets/fonts/Marianne/Marianne-Medium_Italic.woff2') format('woff2'),
+    url(':/assets/fonts/Marianne/Marianne-Medium_Italic.woff') format('woff');
   font-weight: 500;
   font-style: italic;
 }
@@ -69,16 +70,16 @@
 @font-face {
   font-family: Marianne;
   src:
-    url('Marianne-Bold.woff2') format('woff2'),
-    url('Marianne-Bold.woff') format('woff');
+    url(':/assets/fonts/Marianne/Marianne-Bold.woff2') format('woff2'),
+    url(':/assets/fonts/Marianne/Marianne-Bold.woff') format('woff');
   font-weight: 700;
 }
 
 @font-face {
   font-family: Marianne;
   src:
-    url('Marianne-Bold_Italic.woff2') format('woff2'),
-    url('Marianne-Bold_Italic.woff') format('woff');
+    url(':/assets/fonts/Marianne/Marianne-Bold_Italic.woff2') format('woff2'),
+    url(':/assets/fonts/Marianne/Marianne-Bold_Italic.woff') format('woff');
   font-weight: 700;
   font-style: italic;
 }
@@ -86,16 +87,16 @@
 @font-face {
   font-family: Marianne;
   src:
-    url('Marianne-ExtraBold.woff2') format('woff2'),
-    url('Marianne-ExtraBold.woff') format('woff');
+    url(':/assets/fonts/Marianne/Marianne-ExtraBold.woff2') format('woff2'),
+    url(':/assets/fonts/Marianne/Marianne-ExtraBold.woff') format('woff');
   font-weight: 800;
 }
 
 @font-face {
   font-family: Marianne;
   src:
-    url('Marianne-ExtraBold_Italic.woff2') format('woff2'),
-    url('Marianne-ExtraBold_Italic.woff') format('woff');
+    url(':/assets/fonts/Marianne/Marianne-ExtraBold_Italic.woff2') format('woff2'),
+    url(':/assets/fonts/Marianne/Marianne-ExtraBold_Italic.woff') format('woff');
   font-weight: 800;
   font-style: italic;
 }

--- a/src/index.scss
+++ b/src/index.scss
@@ -1,3 +1,2 @@
 @use "./library";
 @use "cunningham-tokens";
-@import url("./assets/fonts/Marianne/Marianne-font.css");

--- a/src/library.scss
+++ b/src/library.scss
@@ -22,3 +22,4 @@
 @use "./components/form/select";
 @use "./components/form/textarea";
 @use "./components/datagrid";
+@use "./assets/fonts/Marianne/Marianne-font.css";


### PR DESCRIPTION
- Updated font file paths in Marianne-font.css to use full asset path
- Moved font import from index.scss to library.scss
- Removed theme prop from CunninghamProvider in Storybook preview