### PR TITLE
✨(tree-view) enhance child item handling in the useTree hook

### DIFF
--- a/src/components/tree-view/useTree.tsx
+++ b/src/components/tree-view/useTree.tsx
@@ -104,15 +104,22 @@ export const useTree = <T,>(
     }
 
     let newSubItems: TreeViewDataType<T>[] | null = item.value.children ?? null;
+    const childrenCount =
+      updatedData.childrenCount ?? item.value.childrenCount ?? 0;
+
+    if (newSubItems?.length === 0 && childrenCount > 0) {
+      newSubItems = null;
+    }
 
     if (updatedData.children) {
       newSubItems = [...(newSubItems ?? []), ...updatedData.children];
     }
+
     const updatedItem: TreeViewDataType<T> = {
       ...item.value,
       ...updatedData,
       children: newSubItems,
-      childrenCount: newSubItems?.length ?? item.value.childrenCount,
+      childrenCount: newSubItems?.length ?? childrenCount,
     } as TreeViewDataType<T>;
 
     update(nodeId, updatedItem);


### PR DESCRIPTION
- Improved logic for determining the children count when updating tree items.
- Added a condition to set newSubItems to null if there are no children but a children count exists.
- Refactored the childrenCount assignment to use a more reliable source.